### PR TITLE
Master patch setuptools

### DIFF
--- a/pyprojcet.toml
+++ b/pyprojcet.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ PACKAGE = 'ibm_db_django'
 VERSION = __import__('ibm_db_django').__version__
 LICENSE = 'Apache License 2.0'
 extra = {}
-if sys.version_info >= (3, ):
-    extra['use_2to3'] = True
     
 setup (
     name              = PACKAGE,


### PR DESCRIPTION
@duongpc Looks like this branch is what mtdirect2-prototype's `requirements.txt` was using, not `master`, 
I think we need these changes to resolve the build error?

![image](https://github.com/user-attachments/assets/fedbf30c-8239-4fb0-a093-4e85670ded8b)
