### PR TITLE
[SD-88672] USE CURRENTLY COMMITTED with all SELECT statements from Django ORM

### DIFF
--- a/ibm_db_django/pybase.py
+++ b/ibm_db_django/pybase.py
@@ -321,7 +321,9 @@ class DB2CursorWrapper( Database.Cursor ):
                 if operation.count( "%s" ) > 0:
                     operation = operation.replace("%s", "?")
 
-            # Ensure SELECT statements have WITH NC to read locked records.
+            # Ensure SELECT statements have WITH NC and USE CURRENTLY COMMITTED to read locked records.
+            # - https://www.ibm.com/docs/en/i/7.4?topic=statement-isolation-clause
+            # - https://www.ibm.com/docs/en/i/7.4?topic=statement-concurrent-access-resolution-clause
             # update final sql before execute so we can read locked records from iseries db
             # sql is original generated from as_sql in SQL compilier
             # but the generated sql may not be final, looks like it still get processed in several places
@@ -329,6 +331,8 @@ class DB2CursorWrapper( Database.Cursor ):
             # `WITH` at start also indicates it's a SELECT statement, since the WITH is the start of a CTE (Common Table Expressions), and CTEs can only be used in SELECT statements
             if is_select_statement and ' WITH NC' not in operation:
                 operation = operation + ' WITH NC'
+            if is_select_statement and ' WITH NC' not in operation:
+                operation = operation + ' USE CURRENTLY COMMITTED'
 
             if ( djangoVersion[0:2] <= ( 1, 1 ) ):
                 if ( doReorg == 1 ):

--- a/ibm_db_django/pybase.py
+++ b/ibm_db_django/pybase.py
@@ -331,7 +331,7 @@ class DB2CursorWrapper( Database.Cursor ):
             # `WITH` at start also indicates it's a SELECT statement, since the WITH is the start of a CTE (Common Table Expressions), and CTEs can only be used in SELECT statements
             if is_select_statement and ' WITH NC' not in operation:
                 operation = operation + ' WITH NC'
-            if is_select_statement and ' WITH NC' not in operation:
+            if is_select_statement and ' USE CURRENTLY COMMITTED' not in operation:
                 operation = operation + ' USE CURRENTLY COMMITTED'
 
             if ( djangoVersion[0:2] <= ( 1, 1 ) ):


### PR DESCRIPTION
[SD-88672] USE CURRENTLY COMMITTED with all SELECT statements from Django ORM

Adding WITH NC to the get_as400_raw_sql_queryset queries didn't actually work..
Performance was still the same on field vs prod.

This change seems to bring it down significantly. Every request in the 20s of seconds are with this change, every request in the 30s of seconds are without this change:
![image](https://github.com/user-attachments/assets/fdfc3631-fae5-4322-90ad-73fc7201b7d3)
(This testing is done after hours)
Considering the overhead on local (it's common for simple requests take 7 seconds) I think this might solve the performance problem.
 

[SD-88672]: https://mgcsupport.atlassian.net/browse/SD-88672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ